### PR TITLE
Фикс для свойства с типом json

### DIFF
--- a/src/DBD/Entity/Entity.php
+++ b/src/DBD/Entity/Entity.php
@@ -289,7 +289,7 @@ abstract class Entity
                 $this->$setterMethod($columnValue);
             } else {
                 /** If initially column type is json, then let's parse it as JSON */
-                if (!is_null($columnValue) && !is_null($fieldDefinition->originType) && stripos($fieldDefinition->originType, "json") !== false) {
+                if (is_string($columnValue) && !is_null($fieldDefinition->originType) && stripos($fieldDefinition->originType, "json") !== false) {
                     $this->$property = json_decode($columnValue, true);
                 } else {
                     /**


### PR DESCRIPTION
Фикс для свойства с типом json у сущности которая была загружена через Embedded с типом json. Устраняет ошибку 
json_decode(): Argument #1 ($json) must be of type string, array given